### PR TITLE
Feature/define frame coords class

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Below you can find an example of how it works in code. Check out `main.py` for m
 An example of `print(identified_invader.pretty_representation())` would look like:
 ```python
     Similarity ratio: 0.859375
-    Coords on map: [[82, 41], [89, 48]]
+    Coords on map: ((18, 49), (25, 6))
     Visual representation:
     ---oo---
     --ooooo-

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,0 +1,14 @@
+class FrameCoords:
+    def __init__(self, x_left: int, y_top: int, x_right: int, y_bottom: int):
+        self.x_left: int = x_left
+        self.y_top: int = y_top
+        self.x_right: int = x_right
+        self.y_bottom: int = y_bottom
+
+    @property
+    def top_left_corner(self) -> [int, int]:
+        return self.x_left, self.y_top
+
+    @property
+    def bottom_right_corner(self) -> [int, int]:
+        return self.x_right, self.y_bottom

--- a/core/utils.py
+++ b/core/utils.py
@@ -12,3 +12,6 @@ class FrameCoords:
     @property
     def bottom_right_corner(self) -> [int, int]:
         return self.x_right, self.y_bottom
+
+    def __str__(self):
+        return f"(({self.x_left}, {self.y_top}), ({self.x_right}, {self.y_bottom}))"

--- a/invaders/base.py
+++ b/invaders/base.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 
 from core.exceptions import NoSignalException
 from core.types import Frame
+from core.utils import FrameCoords
 
 
 class PrettyRepresentationABC(ABC):
@@ -111,7 +112,7 @@ class IdentifiedInvader(PrettyRepresentationABC, ABC):
         original: Invader,
         binary_matrix: Frame,
         similarity_ratio: float,
-        frame_coords_on_map: list[int],
+        frame_coords_on_map: FrameCoords,
     ):
         self.original_invader = original
         self.pattern = binary_matrix

--- a/maps/ascii.py
+++ b/maps/ascii.py
@@ -47,13 +47,21 @@ class AsciiSphericalMap(AsciiMap, Map):
         """
         frame = Frame([])
         if frame_coords.y_top <= frame_coords.y_bottom:
-            for row in self.representation[frame_coords.y_top:frame_coords.y_bottom + 1]:
-                frame.append(self.get_row_subset(row, frame_coords.x_left, frame_coords.x_right))
+            for row in self.representation[
+                frame_coords.y_top:frame_coords.y_bottom + 1
+            ]:
+                frame.append(
+                    self.get_row_subset(row, frame_coords.x_left, frame_coords.x_right)
+                )
         else:
             for row in self.representation[frame_coords.y_top:]:
-                frame.append(self.get_row_subset(row, frame_coords.x_left, frame_coords.x_right))
+                frame.append(
+                    self.get_row_subset(row, frame_coords.x_left, frame_coords.x_right)
+                )
             for row in self.representation[:frame_coords.y_bottom + 1]:
-                frame.append(self.get_row_subset(row, frame_coords.x_left, frame_coords.x_right))
+                frame.append(
+                    self.get_row_subset(row, frame_coords.x_left, frame_coords.x_right)
+                )
 
         return frame
 
@@ -62,4 +70,4 @@ class AsciiSphericalMap(AsciiMap, Map):
         if x_start <= x_end:
             return row[x_start:x_end + 1]
         else:
-            return row[x_start:] + row[: x_end + 1]
+            return row[x_start:] + row[:x_end + 1]

--- a/maps/ascii.py
+++ b/maps/ascii.py
@@ -1,6 +1,7 @@
 from core.exceptions import EmptyMapException
 from core.mixins import AsciiToBinaryMixin, BinaryToAsciiMixin
 from core.types import Frame
+from core.utils import FrameCoords
 from maps.base import Map
 
 
@@ -17,15 +18,15 @@ class AsciiMap(AsciiToBinaryMixin, BinaryToAsciiMixin, Map):
         if not binary_matrix:
             raise EmptyMapException("A Map should not be empty.")
 
-    def get_frame_at(self, x_start: int, y_start: int, x_end: int, y_end: int) -> Frame:
+    def get_frame_at(self, frame_coords: FrameCoords) -> Frame:
         frame = Frame([])
-        for i in range(y_start, y_end + 1):
-            row = self.representation[i][x_start:x_end + 1]
+        for i in range(frame_coords.y_top, frame_coords.y_bottom + 1):
+            row = self.representation[i][frame_coords.x_left:frame_coords.x_right + 1]
             frame.append(row)
         return frame
 
-    def print_frame_at(self, x_start: int, y_start: int, x_end: int, y_end: int):
-        frame = self.get_frame_at(x_start, y_start, x_end, y_end)
+    def print_frame_at(self, frame_coords: FrameCoords):
+        frame = self.get_frame_at(frame_coords)
         ascii_string = self.convert_binary_matrix_to_ascii(frame)
         print(ascii_string)
 
@@ -35,27 +36,24 @@ class AsciiSphericalMap(AsciiMap, Map):
     A map represented as ASCII characters.
     """
 
-    def get_frame_at(self, x_start: int, y_start: int, x_end: int, y_end: int) -> Frame:
+    def get_frame_at(self, frame_coords: FrameCoords) -> Frame:
         """
         Allows retrieval of frames assuming the map is spherical and coordinates
         can wrap (i.e. x_end and y_end coordinates can be smaller than x_start and
         y_start).
 
-        :param x_start: X coordinate of top-left corner of the frame.
-        :param y_start: Y coordinate of top-left corner of the frame.
-        :param x_end: X coordinate of bottom-right corner of the frame.
-        :param y_end: Y coordinate of bottom-right corner of the frame.
+        :param frame_coords: The coordinates of the frame
         :return: The frame.
         """
         frame = Frame([])
-        if y_start <= y_end:
-            for row in self.representation[y_start:y_end + 1]:
-                frame.append(self.get_row_subset(row, x_start, x_end))
+        if frame_coords.y_top <= frame_coords.y_bottom:
+            for row in self.representation[frame_coords.y_top:frame_coords.y_bottom + 1]:
+                frame.append(self.get_row_subset(row, frame_coords.x_left, frame_coords.x_right))
         else:
-            for row in self.representation[y_start:]:
-                frame.append(self.get_row_subset(row, x_start, x_end))
-            for row in self.representation[:y_end + 1]:
-                frame.append(self.get_row_subset(row, x_start, x_end))
+            for row in self.representation[frame_coords.y_top:]:
+                frame.append(self.get_row_subset(row, frame_coords.x_left, frame_coords.x_right))
+            for row in self.representation[:frame_coords.y_bottom + 1]:
+                frame.append(self.get_row_subset(row, frame_coords.x_left, frame_coords.x_right))
 
         return frame
 

--- a/maps/base.py
+++ b/maps/base.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 
 from core.types import Frame
+from core.utils import FrameCoords
 
 
 class Map(ABC):
@@ -25,7 +26,11 @@ class Map(ABC):
         self.representation = representation
 
     @abstractmethod
-    def print_frame_at(self, x_start: int, y_start: int, x_end: int, y_end: int):
+    def print_frame_at(self, frame_coords: FrameCoords):
+        raise NotImplementedError("Method not implemented.")
+
+    @abstractmethod
+    def get_frame_at(self, frame_coords: FrameCoords) -> Frame:
         raise NotImplementedError("Method not implemented.")
 
     def get_binary_representation(self):
@@ -38,10 +43,6 @@ class Map(ABC):
     @property
     def height(self):
         return len(self.representation)
-
-    @abstractmethod
-    def get_frame_at(self, x_start: int, y_start: int, x_end: int, y_end: int) -> Frame:
-        raise NotImplementedError("Method not implemented.")
 
     def __str__(self):
         return "\n".join(["".join(map(str, row)) for row in self.representation])

--- a/radars/area.py
+++ b/radars/area.py
@@ -34,7 +34,12 @@ class DPAreaRadar(DynamicProgrammingMixin, Radar):
         if current_x + invader_width - 1 < map_width:
             if current_y + invader_height - 1 < map_height:
                 self.current_coords[0] += 1
-                return FrameCoords(current_x, current_y, current_x + invader_width - 1, current_y + invader_height - 1)
+                return FrameCoords(
+                    current_x,
+                    current_y,
+                    current_x + invader_width - 1,
+                    current_y + invader_height - 1,
+                )
             else:
                 self.map_scanned = True
                 return None
@@ -42,9 +47,7 @@ class DPAreaRadar(DynamicProgrammingMixin, Radar):
             self.current_coords = [0, current_y + 1]
             return self.get_next_frame_coords()
 
-    def compute_frame_signal_bits_amount(
-        self, frame_coords: FrameCoords
-    ) -> int:
+    def compute_frame_signal_bits_amount(self, frame_coords: FrameCoords) -> int:
         """
         Compute how many signal bits are there in the frame with the provided coordinates.
         In order to optimize this process and not parse the entire frame each time this
@@ -83,11 +86,15 @@ class DPAreaRadar(DynamicProgrammingMixin, Radar):
         c_signal_bits = 0
         d_signal_bits = self.dp_matrix[frame_coords.y_bottom][frame_coords.x_right]
         if frame_coords.x_left > 0:
-            c_signal_bits = self.dp_matrix[frame_coords.y_bottom][frame_coords.x_left - 1]
+            c_signal_bits = self.dp_matrix[frame_coords.y_bottom][
+                frame_coords.x_left - 1
+            ]
         if frame_coords.y_top > 0:
             b_signal_bits = self.dp_matrix[frame_coords.y_top - 1][frame_coords.x_right]
         if frame_coords.x_left > 0 and frame_coords.y_top > 0:
-            a_signal_bits = self.dp_matrix[frame_coords.y_top - 1][frame_coords.x_left - 1]
+            a_signal_bits = self.dp_matrix[frame_coords.y_top - 1][
+                frame_coords.x_left - 1
+            ]
 
         return d_signal_bits - c_signal_bits - b_signal_bits + a_signal_bits
 

--- a/radars/area.py
+++ b/radars/area.py
@@ -1,4 +1,5 @@
 from core.mixins import DynamicProgrammingMixin
+from core.utils import FrameCoords
 from invaders.base import IdentifiedInvader
 from maps.base import Map
 from radars.base import Radar
@@ -18,34 +19,31 @@ class DPAreaRadar(DynamicProgrammingMixin, Radar):
         self.map_scanned = False
         self.identified_invaders: list[IdentifiedInvader] = []
 
-    def get_next_frame_coords(self) -> [[int, int], [int, int]]:
+    def get_next_frame_coords(self) -> FrameCoords | None:
         """
         Compute the coordinates of the next available frame within the map.
         :return: A list made of the coordinates of the top left and bottom right points.
         """
         if self.map_scanned:
-            return []
+            return None
 
-        invader_width, invader_height = self.scanner.required_frame_coords
+        invader_width, invader_height = self.scanner.required_frame_size
         current_x, current_y = self.current_coords
         map_width, map_height = self.map.width, self.map.height
 
         if current_x + invader_width - 1 < map_width:
             if current_y + invader_height - 1 < map_height:
                 self.current_coords[0] += 1
-                return [
-                    [current_x, current_y],
-                    [current_x + invader_width - 1, current_y + invader_height - 1],
-                ]
+                return FrameCoords(current_x, current_y, current_x + invader_width - 1, current_y + invader_height - 1)
             else:
                 self.map_scanned = True
-                return []
+                return None
         else:
             self.current_coords = [0, current_y + 1]
             return self.get_next_frame_coords()
 
     def compute_frame_signal_bits_amount(
-        self, frame_coords: [[int, int], [int, int]]
+        self, frame_coords: FrameCoords
     ) -> int:
         """
         Compute how many signal bits are there in the frame with the provided coordinates.
@@ -80,17 +78,16 @@ class DPAreaRadar(DynamicProgrammingMixin, Radar):
         :param frame_coords: The coordinates of the frame for which to compute the signal bits
         :return: Number of signal bits in the frame.
         """
-        [top_x, top_y], [bottom_x, bottom_y] = frame_coords
         a_signal_bits = 0
         b_signal_bits = 0
         c_signal_bits = 0
-        d_signal_bits = self.dp_matrix[bottom_y][bottom_x]
-        if top_x > 0:
-            c_signal_bits = self.dp_matrix[bottom_y][top_x - 1]
-        if top_y > 0:
-            b_signal_bits = self.dp_matrix[top_y - 1][bottom_x]
-        if top_x > 0 and top_y > 0:
-            a_signal_bits = self.dp_matrix[top_y - 1][top_x - 1]
+        d_signal_bits = self.dp_matrix[frame_coords.y_bottom][frame_coords.x_right]
+        if frame_coords.x_left > 0:
+            c_signal_bits = self.dp_matrix[frame_coords.y_bottom][frame_coords.x_left - 1]
+        if frame_coords.y_top > 0:
+            b_signal_bits = self.dp_matrix[frame_coords.y_top - 1][frame_coords.x_right]
+        if frame_coords.x_left > 0 and frame_coords.y_top > 0:
+            a_signal_bits = self.dp_matrix[frame_coords.y_top - 1][frame_coords.x_left - 1]
 
         return d_signal_bits - c_signal_bits - b_signal_bits + a_signal_bits
 
@@ -105,8 +102,7 @@ class DPAreaRadar(DynamicProgrammingMixin, Radar):
                 frame_coords
             )
             if self.scanner.is_worth_processing_frame(frame_signal_bits_amount):
-                [x_start, y_start], [x_end, y_end] = frame_coords
-                frame = self.map.get_frame_at(x_start, y_start, x_end, y_end)
+                frame = self.map.get_frame_at(frame_coords)
                 similarity_ratio = self.scanner.process_frame(frame)
                 if similarity_ratio >= self.scanner.similarity_threshold:
                     identified_invader = self.identified_invader_class(

--- a/radars/base.py
+++ b/radars/base.py
@@ -36,7 +36,7 @@ class Radar(ABC):
         raise NotImplementedError("Method not implemented.")
 
     def validate_inputs(self):
-        invader_width, invader_height = self.scanner.required_frame_coords
+        invader_width, invader_height = self.scanner.required_frame_size
         if invader_width > self.map.width or invader_height > self.map.height:
             raise MapTooSmallException(
                 "Invader pattern size cannot be bigger than map size."

--- a/radars/spherical.py
+++ b/radars/spherical.py
@@ -60,9 +60,7 @@ class DPSphericalRadar(DPAreaRadar):
             self.current_coords = [0, current_y + 1]
             return self.get_next_frame_coords()
 
-    def compute_frame_signal_bits_amount(
-        self, frame_coords: FrameCoords
-    ) -> int:
+    def compute_frame_signal_bits_amount(self, frame_coords: FrameCoords) -> int:
         """
         If the frame does not wrap around on any direction, use the inherited way
         of DP matrix, which is optimized.
@@ -86,7 +84,10 @@ class DPSphericalRadar(DPAreaRadar):
         :param frame_coords: The coordinates of the frame for which to compute the signal bits
         :return: Number of signal bits in the frame.
         """
-        if frame_coords.x_left <= frame_coords.x_right and frame_coords.y_top <= frame_coords.y_bottom:
+        if (
+            frame_coords.x_left <= frame_coords.x_right
+            and frame_coords.y_top <= frame_coords.y_bottom
+        ):
             return super().compute_frame_signal_bits_amount(frame_coords)
 
         a_signal_bits = 0
@@ -105,8 +106,14 @@ class DPSphericalRadar(DPAreaRadar):
         # compute the signal ratio of the wrapped square as well.
         if frame_coords.y_bottom < frame_coords.y_top:
             d_bottom_y = map_height_y
-            b_frame_x_right = frame_coords.x_right if frame_coords.x_right > frame_coords.x_left else map_width_x
-            b_frame_coords = FrameCoords(frame_coords.x_left, 0, b_frame_x_right, frame_coords.y_bottom)
+            b_frame_x_right = (
+                frame_coords.x_right
+                if frame_coords.x_right > frame_coords.x_left
+                else map_width_x
+            )
+            b_frame_coords = FrameCoords(
+                frame_coords.x_left, 0, b_frame_x_right, frame_coords.y_bottom
+            )
             b_signal_bits = super().compute_frame_signal_bits_amount(b_frame_coords)
 
         # if x_right coordinates are wrapped, they will be smaller that the left
@@ -114,16 +121,29 @@ class DPSphericalRadar(DPAreaRadar):
         # compute the signal ratio of the wrapped square as well.
         if frame_coords.x_right < frame_coords.x_left:
             d_right_x = map_width_x
-            c_frame_bottom_y = frame_coords.y_bottom if frame_coords.y_bottom > frame_coords.y_top else map_height_y
-            c_frame_coords = FrameCoords(0, frame_coords.y_top, frame_coords.x_right, c_frame_bottom_y)
+            c_frame_bottom_y = (
+                frame_coords.y_bottom
+                if frame_coords.y_bottom > frame_coords.y_top
+                else map_height_y
+            )
+            c_frame_coords = FrameCoords(
+                0, frame_coords.y_top, frame_coords.x_right, c_frame_bottom_y
+            )
             c_signal_bits = super().compute_frame_signal_bits_amount(c_frame_coords)
 
         # if the frame wraps on both directions, we need to compute signal bits in A
-        if frame_coords.x_right < frame_coords.x_left and frame_coords.y_bottom < frame_coords.y_top:
-            a_frame_coords = FrameCoords(0, 0, frame_coords.x_right, frame_coords.y_bottom)
+        if (
+            frame_coords.x_right < frame_coords.x_left
+            and frame_coords.y_bottom < frame_coords.y_top
+        ):
+            a_frame_coords = FrameCoords(
+                0, 0, frame_coords.x_right, frame_coords.y_bottom
+            )
             a_signal_bits = super().compute_frame_signal_bits_amount(a_frame_coords)
 
-        d_frame_coords = FrameCoords(frame_coords.x_left, frame_coords.y_top, d_right_x, d_bottom_y)
+        d_frame_coords = FrameCoords(
+            frame_coords.x_left, frame_coords.y_top, d_right_x, d_bottom_y
+        )
         d_signal_bits = super().compute_frame_signal_bits_amount(d_frame_coords)
 
         return a_signal_bits + b_signal_bits + c_signal_bits + d_signal_bits

--- a/radars/spherical.py
+++ b/radars/spherical.py
@@ -1,3 +1,4 @@
+from core.utils import FrameCoords
 from radars.area import DPAreaRadar
 
 
@@ -7,7 +8,7 @@ class DPSphericalRadar(DPAreaRadar):
     Uses dynamic programming to improve performance of search.
     """
 
-    def get_next_frame_coords(self) -> [[int, int], [int, int]]:
+    def get_next_frame_coords(self) -> FrameCoords | None:
         """
         Compute the coordinates of the next available frame within the map.
 
@@ -30,9 +31,9 @@ class DPSphericalRadar(DPAreaRadar):
         :return: A list made of the coordinates of the top left and bottom right points.
         """
         if self.map_scanned:
-            return []
+            return None
 
-        invader_width, invader_height = self.scanner.required_frame_coords
+        invader_width, invader_height = self.scanner.required_frame_size
         current_x, current_y = self.current_coords
         map_width, map_height = self.map.width, self.map.height
 
@@ -51,16 +52,16 @@ class DPSphericalRadar(DPAreaRadar):
                 if y_bottom >= map_height:
                     y_bottom -= map_height
 
-                return [[current_x, current_y], [x_right, y_bottom]]
+                return FrameCoords(current_x, current_y, x_right, y_bottom)
             else:
                 self.map_scanned = True
-                return []
+                return None
         else:
             self.current_coords = [0, current_y + 1]
             return self.get_next_frame_coords()
 
     def compute_frame_signal_bits_amount(
-        self, frame_coords: [[int, int], [int, int]]
+        self, frame_coords: FrameCoords
     ) -> int:
         """
         If the frame does not wrap around on any direction, use the inherited way
@@ -85,8 +86,7 @@ class DPSphericalRadar(DPAreaRadar):
         :param frame_coords: The coordinates of the frame for which to compute the signal bits
         :return: Number of signal bits in the frame.
         """
-        [top_x, top_y], [bottom_x, bottom_y] = frame_coords
-        if top_x <= bottom_x and top_y <= bottom_y:
+        if frame_coords.x_left <= frame_coords.x_right and frame_coords.y_top <= frame_coords.y_bottom:
             return super().compute_frame_signal_bits_amount(frame_coords)
 
         a_signal_bits = 0
@@ -97,30 +97,33 @@ class DPSphericalRadar(DPAreaRadar):
         # top-left corner of the frame, to the bottom-right corner of the map
         map_width_x = self.map.width - 1
         map_height_y = self.map.height - 1
-        d_bottom_x = bottom_x
-        d_bottom_y = bottom_y
+        d_right_x = frame_coords.x_right
+        d_bottom_y = frame_coords.y_bottom
 
-        # if bottom_y coordinates are wrapped, they will be smaller that the top
+        # if y_bottom coordinates are wrapped, they will be smaller that the top
         # coordinates, meaning the frame was wrapped vertically, and we need to
         # compute the signal ratio of the wrapped square as well.
-        if bottom_y < top_y:
+        if frame_coords.y_bottom < frame_coords.y_top:
             d_bottom_y = map_height_y
-            b_frame_bottom_x = bottom_x if bottom_x > top_x else map_width_x
-            b_frame_coords = [[top_x, 0], [b_frame_bottom_x, bottom_y]]
+            b_frame_x_right = frame_coords.x_right if frame_coords.x_right > frame_coords.x_left else map_width_x
+            b_frame_coords = FrameCoords(frame_coords.x_left, 0, b_frame_x_right, frame_coords.y_bottom)
             b_signal_bits = super().compute_frame_signal_bits_amount(b_frame_coords)
 
-        if bottom_x < top_x:
-            d_bottom_x = map_width_x
-            c_frame_bottom_y = bottom_y if bottom_y > top_y else map_height_y
-            c_frame_coords = [[0, top_y], [bottom_x, c_frame_bottom_y]]
+        # if x_right coordinates are wrapped, they will be smaller that the left
+        # coordinates, meaning the frame was wrapped horizontally, and we need to
+        # compute the signal ratio of the wrapped square as well.
+        if frame_coords.x_right < frame_coords.x_left:
+            d_right_x = map_width_x
+            c_frame_bottom_y = frame_coords.y_bottom if frame_coords.y_bottom > frame_coords.y_top else map_height_y
+            c_frame_coords = FrameCoords(0, frame_coords.y_top, frame_coords.x_right, c_frame_bottom_y)
             c_signal_bits = super().compute_frame_signal_bits_amount(c_frame_coords)
 
         # if the frame wraps on both directions, we need to compute signal bits in A
-        if bottom_x < top_x and bottom_y < top_y:
-            a_frame_coords = [[0, 0], [bottom_x, bottom_y]]
+        if frame_coords.x_right < frame_coords.x_left and frame_coords.y_bottom < frame_coords.y_top:
+            a_frame_coords = FrameCoords(0, 0, frame_coords.x_right, frame_coords.y_bottom)
             a_signal_bits = super().compute_frame_signal_bits_amount(a_frame_coords)
 
-        d_frame_coords = [[top_x, top_y], [d_bottom_x, d_bottom_y]]
+        d_frame_coords = FrameCoords(frame_coords.x_left, frame_coords.y_top, d_right_x, d_bottom_y)
         d_signal_bits = super().compute_frame_signal_bits_amount(d_frame_coords)
 
         return a_signal_bits + b_signal_bits + c_signal_bits + d_signal_bits

--- a/scanners/base.py
+++ b/scanners/base.py
@@ -36,7 +36,7 @@ class Scanner(ABC):
         raise NotImplementedError("Method not implemented.")
 
     @property
-    def required_frame_coords(self) -> tuple[int, int]:
+    def required_frame_size(self) -> tuple[int, int]:
         """
         The size of the necessary frame to be provided to the scanner.
         :return: The width and height of the expected frame.

--- a/tests/test_frame_coords.py
+++ b/tests/test_frame_coords.py
@@ -1,0 +1,16 @@
+from core.utils import FrameCoords
+
+
+def test_frame_coords():
+    # setup
+    coords = FrameCoords(1, 2, 3, 4)
+    expected_top_left = 1, 2
+    expected_bottom_right = 3, 4
+
+    # run
+    top_left = coords.top_left_corner
+    bottom_right = coords.bottom_right_corner
+
+    # assert
+    assert top_left == expected_top_left
+    assert bottom_right == expected_bottom_right

--- a/tests/test_maps.py
+++ b/tests/test_maps.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from core.exceptions import EmptyMapException
+from core.utils import FrameCoords
 from maps.ascii import AsciiMap, AsciiSphericalMap
 
 
@@ -50,7 +51,7 @@ def test_ascii_map_get_frame_at(mocked_convert_method, map_binary_repr):
     ]
 
     # run
-    frame = ascii_map.get_frame_at(1, 1, 3, 2)
+    frame = ascii_map.get_frame_at(FrameCoords(1, 1, 3, 2))
 
     # assert
     assert frame == expected_result
@@ -78,9 +79,10 @@ def test_ascii_spherical_map_get_frame_at(
     # setup
     mocked_convert_method.return_value = map_binary_repr
     ascii_map = AsciiSphericalMap("")
+    frame_coords = FrameCoords(x_start, y_start, x_end, y_end)
 
     # run
-    frame = ascii_map.get_frame_at(x_start, y_start, x_end, y_end)
+    frame = ascii_map.get_frame_at(frame_coords)
 
     # assert
     assert frame == expected_result

--- a/tests/test_radars.py
+++ b/tests/test_radars.py
@@ -4,6 +4,7 @@ import pytest
 
 from core.exceptions import MapTooSmallException
 from core.types import Frame
+from core.utils import FrameCoords
 from invaders.identified import AsciiIdentifiedInvader
 from maps.ascii import AsciiMap
 from radars.area import DPAreaRadar
@@ -17,7 +18,7 @@ def test_dp_area_radar_validate_inputs_successfully(mock_compute_dp_matrix):
     map_.width = 3
     map_.height = 3
     scanner = mock.Mock()
-    scanner.required_frame_coords = [2, 3]
+    scanner.required_frame_size = [2, 3]
 
     # run & assert
     DPAreaRadar(map_, scanner)
@@ -31,68 +32,33 @@ def test_dp_area_radar_validate_inputs_raises_exception(mock_compute_dp_matrix):
     map_.width = 3
     map_.height = 3
     scanner = mock.Mock()
-    scanner.required_frame_coords = [2, 4]
+    scanner.required_frame_size = [2, 4]
 
     # run & assert
     with pytest.raises(MapTooSmallException):
         DPAreaRadar(map_, scanner)
 
 
-def test_dp_area_radar_compute_frame_signal_bits_amount():
+@pytest.mark.parametrize(
+    "x_start,y_start,x_end,y_end,expected_result",
+    [
+        (2, 1, 4, 2, 3),  # frame in middle
+        (1, 0, 4, 1, 4),  # frame at top
+        (0, 1, 0, 2, 2),  # frame at left
+        (0, 0, 2, 2, 6),  # frame at top left
+    ],
+)
+def test_dp_area_radar_compute_frame_signal_bits_amount(x_start, y_start, x_end, y_end, expected_result):
     # setup
     map_ = AsciiMap("o-oo-\n" "o-o-o\n" "oo--o\n")
     scanner = mock.Mock()
-    scanner.required_frame_coords = [1, 1]
+    scanner.required_frame_size = [1, 1]
     radar = DPAreaRadar(map_, scanner)
-    expected_result = 3
+    expected_result = expected_result
+    frame_coords = FrameCoords(x_start, y_start, x_end, y_end)
 
     # run
-    actual_result = radar.compute_frame_signal_bits_amount([[2, 1], [4, 2]])
-
-    # assert
-    assert actual_result == expected_result
-
-
-def test_dp_area_radar_compute_frame_signal_bits_amount_case_frame_at_top_of_map():
-    # setup
-    map_ = AsciiMap("o-oo-\n" "o-o-o\n" "oo--o\n")
-    scanner = mock.Mock()
-    scanner.required_frame_coords = [1, 1]
-    radar = DPAreaRadar(map_, scanner)
-    expected_result = 4
-
-    # run
-    actual_result = radar.compute_frame_signal_bits_amount([[1, 0], [4, 1]])
-
-    # assert
-    assert actual_result == expected_result
-
-
-def test_dp_area_radar_compute_frame_signal_bits_amount_case_frame_at_left_of_map():
-    # setup
-    map_ = AsciiMap("o-oo-\n" "o-o-o\n" "oo--o\n")
-    scanner = mock.Mock()
-    scanner.required_frame_coords = [1, 1]
-    radar = DPAreaRadar(map_, scanner)
-    expected_result = 2
-
-    # run
-    actual_result = radar.compute_frame_signal_bits_amount([[0, 1], [0, 2]])
-
-    # assert
-    assert actual_result == expected_result
-
-
-def test_dp_area_radar_compute_frame_signal_bits_amount_case_frame_at_top_left_of_map():
-    # setup
-    map_ = AsciiMap("o-oo-\n" "o-o-o\n" "oo--o\n")
-    scanner = mock.Mock()
-    scanner.required_frame_coords = [1, 1]
-    radar = DPAreaRadar(map_, scanner)
-    expected_result = 6
-
-    # run
-    actual_result = radar.compute_frame_signal_bits_amount([[0, 0], [2, 2]])
+    actual_result = radar.compute_frame_signal_bits_amount(frame_coords)
 
     # assert
     assert actual_result == expected_result
@@ -106,19 +72,19 @@ def test_dp_area_radar_get_next_frame_coords(mocked_method):
     map_.height = 4
 
     scanner = mock.Mock()
-    scanner.required_frame_coords = [2, 3]
+    scanner.required_frame_size = [2, 3]
     radar = DPAreaRadar(map_, scanner)
     expected_result = [
-        [[0, 0], [1, 2]],
-        [[1, 0], [2, 2]],
-        [[0, 1], [1, 3]],
-        [[1, 1], [2, 3]],
+        "((0, 0), (1, 2))",
+        "((1, 0), (2, 2))",
+        "((0, 1), (1, 3))",
+        "((1, 1), (2, 3))",
     ]
     actual_result = []
 
     # run
     while frame_coords := radar.get_next_frame_coords():
-        actual_result.append(frame_coords)
+        actual_result.append(str(frame_coords))
 
     # assert
     assert actual_result == expected_result
@@ -131,13 +97,13 @@ def test_dp_area_radar_scan_low_frame_signal_amount(
     mocked_compute_dp, mocket_compute_frame_signal, mocked_get_next_frame
 ):
     # setup
-    dummy_frames = [[[0, 1], [1, 1]], []]
+    dummy_frames = [FrameCoords(0, 1, 1, 1), None]
     map_ = mock.Mock()
     map_.width = 3
     map_.height = 4
     scanner = mock.Mock()
     scanner.is_worth_processing_frame.return_value = False
-    scanner.required_frame_coords = [2, 3]
+    scanner.required_frame_size = [2, 3]
     radar = DPAreaRadar(map_, scanner)
     mocked_get_next_frame.side_effect = dummy_frames
 
@@ -158,7 +124,7 @@ def test_dp_area_radar_scan_high_frame_signal_amount(
     mocked_compute_dp, mocket_compute_frame_signal, mocked_get_next_frame
 ):
     # setup
-    dummy_frames = [[[0, 1], [1, 2]], []]
+    dummy_frames = [FrameCoords(0, 1, 1, 2), None]
     map_frame = Frame([[1, 1], [1, 0], [1, 1]])
     processed_similarity_ratio = 0.7
 
@@ -168,7 +134,7 @@ def test_dp_area_radar_scan_high_frame_signal_amount(
     map_.get_frame_at.return_value = map_frame
 
     scanner = mock.Mock()
-    scanner.required_frame_coords = [2, 3]
+    scanner.required_frame_size = [2, 3]
     scanner.similarity_threshold = 0.6
     scanner.is_worth_processing_frame.return_value = True
     scanner.process_frame.return_value = processed_similarity_ratio
@@ -185,7 +151,7 @@ def test_dp_area_radar_scan_high_frame_signal_amount(
     # assert
     mocked_get_next_frame.assert_called()
     mocket_compute_frame_signal.assert_called_once_with(dummy_frames[0])
-    map_.get_frame_at.assert_called_once_with(0, 1, 1, 2)
+    map_.get_frame_at.assert_called_once_with(dummy_frames[0])
     scanner.process_frame.assert_called_once_with(map_frame)
 
     assert len(radar.get_identified_invaders()) == 1
@@ -203,87 +169,52 @@ def test_dp_spherical_radar_get_next_frame_coords(mocked_method):
     map_.height = 4
 
     scanner = mock.Mock()
-    scanner.required_frame_coords = [2, 3]
+    scanner.required_frame_size = [2, 3]
     radar = DPSphericalRadar(map_, scanner)
     expected_result = [
-        [[0, 0], [1, 2]],
-        [[1, 0], [2, 2]],
-        [[2, 0], [0, 2]],
-        [[0, 1], [1, 3]],
-        [[1, 1], [2, 3]],
-        [[2, 1], [0, 3]],
-        [[0, 2], [1, 0]],
-        [[1, 2], [2, 0]],
-        [[2, 2], [0, 0]],
-        [[0, 3], [1, 1]],
-        [[1, 3], [2, 1]],
-        [[2, 3], [0, 1]],
+        "((0, 0), (1, 2))",
+        "((1, 0), (2, 2))",
+        "((2, 0), (0, 2))",
+        "((0, 1), (1, 3))",
+        "((1, 1), (2, 3))",
+        "((2, 1), (0, 3))",
+        "((0, 2), (1, 0))",
+        "((1, 2), (2, 0))",
+        "((2, 2), (0, 0))",
+        "((0, 3), (1, 1))",
+        "((1, 3), (2, 1))",
+        "((2, 3), (0, 1))",
     ]
     actual_result = []
 
     # run
     while frame_coords := radar.get_next_frame_coords():
-        actual_result.append(frame_coords)
+        actual_result.append(str(frame_coords))
 
     # assert
     assert actual_result == expected_result
 
 
-def test_dp_spherical_radar_compute_frame_signal_bits_amount_case_frame_does_not_wrap():
+@pytest.mark.parametrize(
+    "x_start,y_start,x_end,y_end,expected_result",
+    [
+        (0, 0, 2, 2, 5),  # does not wrap
+        (2, 0, 0, 1, 4),  # wraps horizontally
+        (0, 2, 2, 1, 5),  # wraps vertically
+        (3, 2, 2, 1, 7),  # wraps both ways
+    ],
+)
+def test_dp_spherical_radar_compute_frame_signal_bits_amount(x_start, y_start, x_end, y_end, expected_result):
     # setup
     map_ = AsciiMap("-ooo\n" "o-o-\n" "o--o\n")
     scanner = mock.Mock()
-    scanner.required_frame_coords = [1, 1]
+    scanner.required_frame_size = [1, 1]
     radar = DPSphericalRadar(map_, scanner)
-    expected_result = 5
+    expected_result = expected_result
+    frame_coord = FrameCoords(x_start, y_start, x_end, y_end)
 
     # run
-    actual_result = radar.compute_frame_signal_bits_amount([[0, 0], [2, 2]])
-
-    # assert
-    assert actual_result == expected_result
-
-
-def test_dp_spherical_radar_compute_frame_signal_bits_amount_case_frame_wraps_horizontally():
-    # setup
-    map_ = AsciiMap("-ooo\n" "o-o-\n" "o--o\n")
-    scanner = mock.Mock()
-    scanner.required_frame_coords = [1, 1]
-    radar = DPSphericalRadar(map_, scanner)
-    expected_result = 4
-
-    # run
-    actual_result = radar.compute_frame_signal_bits_amount([[2, 0], [0, 1]])
-
-    # assert
-    assert actual_result == expected_result
-
-
-def test_dp_spherical_radar_compute_frame_signal_bits_amount_case_frame_wraps_vertically():
-    # setup
-    map_ = AsciiMap("-ooo\n" "o-o-\n" "o--o\n")
-    scanner = mock.Mock()
-    scanner.required_frame_coords = [1, 1]
-    radar = DPSphericalRadar(map_, scanner)
-    expected_result = 5
-
-    # run
-    actual_result = radar.compute_frame_signal_bits_amount([[0, 2], [2, 1]])
-
-    # assert
-    assert actual_result == expected_result
-
-
-def test_dp_spherical_radar_compute_frame_signal_bits_amount_case_frame_wraps_both_ways():
-    # setup
-    map_ = AsciiMap("-ooo\n" "o-o-\n" "o--o\n")
-    scanner = mock.Mock()
-    scanner.required_frame_coords = [1, 1]
-    radar = DPSphericalRadar(map_, scanner)
-    expected_result = 7
-
-    # run
-    actual_result = radar.compute_frame_signal_bits_amount([[3, 2], [2, 1]])
+    actual_result = radar.compute_frame_signal_bits_amount(frame_coord)
 
     # assert
     assert actual_result == expected_result

--- a/tests/test_radars.py
+++ b/tests/test_radars.py
@@ -48,7 +48,9 @@ def test_dp_area_radar_validate_inputs_raises_exception(mock_compute_dp_matrix):
         (0, 0, 2, 2, 6),  # frame at top left
     ],
 )
-def test_dp_area_radar_compute_frame_signal_bits_amount(x_start, y_start, x_end, y_end, expected_result):
+def test_dp_area_radar_compute_frame_signal_bits_amount(
+    x_start, y_start, x_end, y_end, expected_result
+):
     # setup
     map_ = AsciiMap("o-oo-\n" "o-o-o\n" "oo--o\n")
     scanner = mock.Mock()
@@ -204,7 +206,9 @@ def test_dp_spherical_radar_get_next_frame_coords(mocked_method):
         (3, 2, 2, 1, 7),  # wraps both ways
     ],
 )
-def test_dp_spherical_radar_compute_frame_signal_bits_amount(x_start, y_start, x_end, y_end, expected_result):
+def test_dp_spherical_radar_compute_frame_signal_bits_amount(
+    x_start, y_start, x_end, y_end, expected_result
+):
     # setup
     map_ = AsciiMap("-ooo\n" "o-o-\n" "o--o\n")
     scanner = mock.Mock()


### PR DESCRIPTION
## PR Type

- [x] New feature
- [ ] Bug fix
- [ ] Other (please specify)

## Implementation Approach

This PR introduces a `FrameCoords` class that allows for better code readability in places where frame coordinates are used in the code. Thus, in place of a list of a pair of pairs (e.g., `[[0, 1], [3, 4]]`) that indicates the x and y coordinates of the top-left and bottom-right corners, the code now expects a `FrameCoords()` instance.

The changes refer to adding the class itself as well as adjusting the code everywhere to use it.

## Tasklist

- [x] Updated documentation
- [x] Added tests
- [x] Run `pytest` successfully
- [x] Run `black .`